### PR TITLE
PL-204: Add Xcode 26.6.x to Xcode versions list

### DIFF
--- a/appcircle_publish_send_to_testflight/1.0.0/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.0.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.1.0/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.1.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.2.0/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.2.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.2.1/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.2.1/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.2.2/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.2.2/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.0/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.1/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.1/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.2/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.2/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.3/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.3/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.4/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.4/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.0/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.0/component.yaml
@@ -18,7 +18,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.1/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.1/component.yaml
@@ -22,7 +22,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.2/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.2/component.yaml
@@ -22,7 +22,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.3/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.3/component.yaml
@@ -22,7 +22,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.


### PR DESCRIPTION
Adds **Xcode 26.6.x** to the `AC_XCODE_VERSION` options of the App Store publish components (send_to_testflight, submit_for_review_appstore, update_metadata_appstore — all versions). Mirrors the 26.5 addition (#243).

Linear: [PL-204](https://linear.app/appcircle/issue/PL-204) (parent [PL-193](https://linear.app/appcircle/issue/PL-193) — Xcode 26.6 RC 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Xcode 26.6.x across iOS publishing, review submission, and metadata management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->