### PR TITLE
PL-271: Add Xcode 27.0.x to publish components Xcode version list

### DIFF
--- a/appcircle_publish_send_to_testflight/1.0.0/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.0.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.1.0/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.1.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.2.0/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.2.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.2.1/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.2.1/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_send_to_testflight/1.2.2/component.yaml
+++ b/appcircle_publish_send_to_testflight/1.2.2/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.0/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.0/component.yaml
@@ -17,7 +17,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.1/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.1/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.2/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.2/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.3/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.3/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_submit_for_review_appstore/1.0.4/component.yaml
+++ b/appcircle_publish_submit_for_review_appstore/1.0.4/component.yaml
@@ -21,7 +21,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.0/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.0/component.yaml
@@ -18,7 +18,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.1/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.1/component.yaml
@@ -22,7 +22,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.2/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.2/component.yaml
@@ -22,7 +22,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.

--- a/appcircle_publish_update_metadata_appstore/1.0.3/component.yaml
+++ b/appcircle_publish_update_metadata_appstore/1.0.3/component.yaml
@@ -22,7 +22,7 @@ inputs:
 - key: "AC_XCODE_VERSION"
   defaultValue: "16.2.x"
   editorType: select
-  options: "26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
+  options: "27.0.x,26.6.x,26.5.x,26.4.x,26.3.x,26.2.x,26.1.x,26.0.x,16.4.x,16.3.x,16.2.x,16.1.x,16.0.x,15.4.x,15.3.x,15.2.x,15.1.x,15.0.x,14.3.x"
   isRequired: true
   title: Xcode Version
   description: Specifies the Xcode version.


### PR DESCRIPTION
## What

Adds Xcode `27.0.x` (the new tahoe26.5 stack) to the `AC_XCODE_VERSION` select across the three publish components, prepended as the newest entry:

- `appcircle_publish_send_to_testflight` (1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.2.2)
- `appcircle_publish_submit_for_review_appstore` (1.0.0 - 1.0.4)
- `appcircle_publish_update_metadata_appstore` (1.0.0 - 1.0.3)

14 `component.yaml` files, options string `26.6.x,…` → `27.0.x,26.6.x,…`. `defaultValue` unchanged (`16.2.x`).

## Why

The publish Xcode lists are maintained manually. Mirrors PL-204 / #250 (which added `26.6.x`). The buildserver list is dynamic since BE-8291, so no `ac-server-build` change is needed.

## Notes / judgment

- `27.0.x` is currently a **beta** (Xcode 27.0 b2, `27A5209h`). It's surfaced in the customer-facing publish dropdown the same way `26.6.x` (an RC) was under #250 - intentional, per the runner rollout.
- `appcircle_xcode_select` is **out of scope** (its `AC_XCODE_VERSION` input isn't an options-based select; #250 didn't touch it either).

Linear: PL-271

Co-authored-by: ilhan <ilhan@appcircle.io>

---
_Created on behalf of ilhan@appcircle.io via Arc._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the available Xcode version choices to include `27.0.x` across several publishing and review-related setups.
  * One update also adds `26.6.x` to the selectable version list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->